### PR TITLE
chore: fix import so it doesnt fail when used as dependency

### DIFF
--- a/src/utils/MSAProxy.sol
+++ b/src/utils/MSAProxy.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";
 import { ERC1967Utils } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
-import { Initializable } from "src/lib/Initializable.sol";
+import { Initializable } from "../lib/Initializable.sol";
 
 contract MSAProxy is Proxy {
     constructor(address implementation, bytes memory _data) payable {


### PR DESCRIPTION
When this repo is used as dependency, and when MSAProxy is pulled into the build and being compiled, this error happens:

```
error: file src/lib/Initializable.sol not found
 --> node_modules/@erc7579/implementation/src/utils/MSAProxy.sol:6:31
```

it happens because it tried to look into the main repo's `src/lib` 
So the suggested fix is to replace path with the relative path
`../lib/Initializable.sol`